### PR TITLE
More robust method for setting the current culture

### DIFF
--- a/src/Suteki.TardisBank.Web/Global.asax.cs
+++ b/src/Suteki.TardisBank.Web/Global.asax.cs
@@ -4,6 +4,7 @@ using System.Web.Routing;
 using Castle.MicroKernel.Registration;
 using Castle.Windsor;
 using Castle.Windsor.Installer;
+using Suteki.TardisBank.Mvc;
 
 namespace Suteki.TardisBank.Web
 {
@@ -15,6 +16,7 @@ namespace Suteki.TardisBank.Web
         public static void RegisterGlobalFilters(GlobalFilterCollection filters)
         {
             filters.Add(new HandleErrorAttribute());
+            filters.Add(new CultureActionFilter());
         }
 
         public static void RegisterRoutes(RouteCollection routes)

--- a/src/Suteki.TardisBank.Web/Suteki.TardisBank.Web.csproj
+++ b/src/Suteki.TardisBank.Web/Suteki.TardisBank.Web.csproj
@@ -14,6 +14,7 @@
     <AssemblyName>Suteki.TardisBank.Web</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
+    <UseIISExpress>false</UseIISExpress>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Suteki.TardisBank/Mvc/CultureActionFilter.cs
+++ b/src/Suteki.TardisBank/Mvc/CultureActionFilter.cs
@@ -1,0 +1,27 @@
+using System.Globalization;
+using System.Threading;
+using System.Web.Mvc;
+
+namespace Suteki.TardisBank.Mvc
+{
+    public class CultureActionFilter : ActionFilterAttribute
+    {
+        public override void OnActionExecuting(ActionExecutingContext filterContext)
+        {
+            var request = filterContext.HttpContext.Request;
+            if(request == null || request.UserLanguages == null)
+            {
+                base.OnActionExecuting(filterContext);
+                return;
+            }
+
+            var culture = new CultureInfo(request.UserLanguages[0]);
+            Thread.CurrentThread.CurrentCulture = culture;
+
+            base.OnActionExecuting(filterContext);
+            
+        }
+
+       
+    }
+}

--- a/src/Suteki.TardisBank/Suteki.TardisBank.csproj
+++ b/src/Suteki.TardisBank/Suteki.TardisBank.csproj
@@ -103,6 +103,7 @@
     <Compile Include="Model\PaymentSchedule.cs" />
     <Compile Include="Model\Transaction.cs" />
     <Compile Include="Model\User.cs" />
+    <Compile Include="Mvc\CultureActionFilter.cs" />
     <Compile Include="Mvc\Current.cs" />
     <Compile Include="Mvc\UnitOfWorkAttribute.cs" />
     <Compile Include="Mvc\UserLocaleModule.cs" />


### PR DESCRIPTION
Hi Mike

I've been using TardisBank for a few months now to manage Zach and Benji's pocket money and it's fantastic. One niggle though is that the dates and currencies are in US format, I guess this is a limitation of the ASP.Net culture fudging mechanism.

So I've changed the way the culture is picked up and created this pull request. I've added a global filter which reads the accepted user language from the request headers and uses this to set the culture of the current thread.

Cheers

Keith
